### PR TITLE
Fixes Null Pointer in RobotLogger

### DIFF
--- a/src/main/java/frc/robot/helper/logging/RobotLogger.java
+++ b/src/main/java/frc/robot/helper/logging/RobotLogger.java
@@ -108,6 +108,10 @@ public class RobotLogger {
         }
     }
     static public void closeFiles(){
+        if (globalLogger == null)
+            setup();
+
+        System.out.println(globalLogger.getHandlers());
         for (Handler handler : globalLogger.getHandlers()){
             handler.close();
         }


### PR DESCRIPTION
## Summary

Accidentally Introduced null pointer exception from closing files of RobotLogger before setup, this fixes it.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] I have read the [Contributing](Contributing.md) document.

- [X] If code changes were made then they have been tested.
