### PR TITLE
RobotLogger doesn't log Network Tables

### DIFF
--- a/src/main/java/frc/robot/helper/logging/RobotLogger.java
+++ b/src/main/java/frc/robot/helper/logging/RobotLogger.java
@@ -46,7 +46,7 @@ public class RobotLogger {
      */
     public static void init(){
         DataLogManager.start();
-        DataLogManager.logNetworkTables(true);
+        DataLogManager.logNetworkTables(false);
     }
 
     /**


### PR DESCRIPTION
Uses wayyy too many entries (>100,00) one time

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] I have read the [Contributing](Contributing.md) document.

- [ ] If code changes were made then they have been tested.
